### PR TITLE
fix: Update package name

### DIFF
--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,1 +1,1 @@
-name: "github.com/kurtosis-tech/spark-py"
+name: "github.com/kurtosis-tech/spark-package"


### PR DESCRIPTION
Package is currently failing due a mismatch between repo name and metadata definition.

```
There was an error interpreting Starlark code 
Error occurred while validating /kurtosis-data/startosis-packages/kurtosis-tech/spark-package/kurtosis.yml
        Caused by: The package name in kurtosis.yml must match the location it is in. Package name is 'github.com/kurtosis-tech/spark-py' and kurtosis.yml is found here: 'github.com/kurtosis-tech/spark-package'
```